### PR TITLE
quita / de routing y agrega ng-controller a sección de formulario

### DIFF
--- a/controllers/appController.js
+++ b/controllers/appController.js
@@ -2,10 +2,6 @@
 
 app.config(function ($routeProvider) {
 	$routeProvider
-		.when('/', {
-			templateUrl: '../index.html',
-			controller: 'testController'
-		})
 		.when('/mostrar-datos',{
 			templateUrl: '../tablaUsuarios.html',
 			controller: 'datosTabla'
@@ -26,7 +22,7 @@ function obtieneDatos($scope, testRequest, $uibModal, $location) {
         testRequest.post().then(function (response) {
         	// post tiene los datos
             $scope.post = response.data[0];
-            seccionStorage.setTime('datos',
+            sessionStorage.setItem('datos',
             		JSON.stringify({
             			id: $scope.post.id,
             			nombre: $scope.post.name,
@@ -34,8 +30,8 @@ function obtieneDatos($scope, testRequest, $uibModal, $location) {
             			email: $scope.post.email
             		})
             	);
-        // mostrar datos en la tabla
-    	$location.path(path);
+		        // mostrar datos en la tabla
+		    	$location.path(path);
         });
     }
 
@@ -44,5 +40,5 @@ function obtieneDatos($scope, testRequest, $uibModal, $location) {
 app.controller('datosTabla',['$scope',mostrarDatos]);
 
 function mostrarDatos($scope) {
-	$scope.objetoUsuarios = JSON.parse(seccionStorage.getItem('datos'));
+	$scope.objetoUsuarios = JSON.parse(sessionStorage.getItem('datos'));
 }

--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css">
 </head>
 <body>
-    <div class="container">
+    <div class="container" ng-controller="testController">
         <div class="row">
             <div class="col-lg-offset-4 col-lg-4 center">
                 <h1 class="center">Obtener Datos</h1>
@@ -17,7 +17,9 @@
                 <button type="button" class="btn btn-primary btn-sm" ng-click="obtenerNombres('/mostrar-datos')">Mostrar Datos</button>
             </div>
         </div>
-            <div ng-view></div>
+    </div>
+    <div class="container">
+      <div ng-view></div>
     </div>
 
     <script src="https://ajax.googleapis.com/ajax/libs/angularjs/1.6.6/angular.min.js"></script>


### PR DESCRIPTION
Estos son los cambios que hice:

* Cuando usas el routing, el path por defecto es `/` y equivale al `index.html` de tu proyecto, por lo tanto no es necesario que lo agregues a tu `config` de rutas.
* Ya que tu `/` es tu `index.html` por defecto, se le debe asignar el `controller` principal en el HTML (en este caso `testController`), por eso se separa en 2 containers, uno para el formulario y otro para los _templates_ (`ng-view`).
* Por cierto, no equivocarse al escribir (_typo_), el objeto global para web storage es `sessionStorage`.
* Por último, el `$location.path()` que se encarga de la redirección, no debe de ir fuera de la promesa, ya que redireccionará sin haber obtenido los datos a tiempo.